### PR TITLE
Added ability to externally retrieve linked IParam

### DIFF
--- a/WDL/IPlug/IControl.h
+++ b/WDL/IPlug/IControl.h
@@ -49,6 +49,7 @@ public:
   void PromptUserInput(IRECT* pTextRect);
 
   int ParamIdx() { return mParamIdx; }
+  IParam *GetParam() { return mPlug->GetParam(mParamIdx); }
   virtual void SetValueFromPlug(double value);
   void SetValueFromUserInput(double value);
   double GetValue() { return mValue; }


### PR DESCRIPTION
This definitely returns a NULL pointer when the paramIdx is < 0. Although there are various comments in IPlug about using paramIdx > kNumParams in fact in my experience this is totally unsafe, and at present should be avoided. This is something I might take a look at fixing at a later time, as as far as I can see you can have non-automated params at the moment, but not params that are hidden entirely from any preset system, which is a useful facility.
