### PR TITLE
Added kAudioUnitParameterFlag_IsElementMeta to AU parameters

### DIFF
--- a/WDL/IPlug/IPlugAU.cpp
+++ b/WDL/IPlug/IPlugAU.cpp
@@ -589,7 +589,8 @@ ComponentResult IPlugAU::GetProperty(AudioUnitPropertyID propID, AudioUnitScope 
         memset(pInfo, 0, sizeof(AudioUnitParameterInfo));
         pInfo->flags = kAudioUnitParameterFlag_CFNameRelease |
                        kAudioUnitParameterFlag_HasCFNameString |
-                       kAudioUnitParameterFlag_IsReadable;
+                       kAudioUnitParameterFlag_IsReadable |
+					   kAudioUnitParameterFlag_IsElementMeta;
         
         IParam* pParam = GetParam(element);
         


### PR DESCRIPTION
Done to be able to use "linked" params, when moving one parameter affects the value of a linked one
