### PR TITLE
Iknobmulticontroltext implementation

### DIFF
--- a/WDL/IPlug/IControl.cpp
+++ b/WDL/IPlug/IControl.cpp
@@ -586,6 +586,57 @@ bool IKnobMultiControl::Draw(IGraphics* pGraphics)
   return pGraphics->DrawBitmap(&mBitmap, &mRECT, i, &mBlend);
 }
 
+
+bool IKnobMultiControlText::Draw(IGraphics* pGraphics)
+{
+	IKnobMultiControl::Draw(pGraphics);
+    
+    char cStr[32];
+    mPlug->GetParam(mParamIdx)->GetDisplayForHost(cStr);
+    mStr.Set(cStr);
+	if (mShowParamLabel) {
+		mStr.Append(" ");
+		mStr.Append(mPlug->GetParam(mParamIdx)->GetLabelForHost());
+	}
+
+    if (CSTR_NOT_EMPTY(cStr)) {
+		// measure the text size
+		pGraphics->DrawIText(&mText, mStr.Get(), &mTextRECT,true);
+		// draw text
+		return pGraphics->DrawIText(&mText, mStr.Get(), &mTextRECT);
+    }
+    return true;
+}
+	
+void IKnobMultiControlText::OnMouseDown(int x, int y, IMouseMod* pMod)
+{
+	if (mTextRECT.Contains(x, y)) PromptUserInput(&mTextRECT);
+#ifdef PROTOOLS
+	else if (pMod->A) {
+		if (mDefaultValue >= 0.0) {
+			mValue = mDefaultValue;
+			SetDirty();
+		}
+	}
+#endif
+	else {
+		OnMouseDrag(x, y, 0, 0, pMod);
+	}
+}
+	
+void IKnobMultiControlText::OnMouseDblClick(int x, int y, IMouseMod* pMod)
+{
+#ifdef PROTOOLS
+	PromptUserInput(&mTextRECT);
+#else
+	if (mDefaultValue >= 0.0) {
+		mValue = mDefaultValue;
+		SetDirty();
+	}
+#endif
+}
+
+
 bool IKnobRotatingMaskControl::Draw(IGraphics* pGraphics)
 {
   double angle = mMinAngle + mValue * (mMaxAngle - mMinAngle);

--- a/WDL/IPlug/IControl.h
+++ b/WDL/IPlug/IControl.h
@@ -353,6 +353,7 @@ protected:
   IBitmap mBitmap;
 };
 
+
 // A knob that consists of a static base, a rotating mask, and a rotating top.
 // The bitmaps are assumed to be symmetrical and identical sizes.
 class IKnobRotatingMaskControl : public IKnobControl
@@ -476,6 +477,52 @@ protected:
   WDL_String mDir, mFile, mExtensions;
   EFileAction mFileAction;
   EFileSelectorState mState;
+};
+
+class IKnobMultiControlText : public IKnobMultiControl  
+{
+	
+public:
+	
+	enum EKnobMultiControlTextPosition { kTxtPosBelow, kTxtPosAbove, kTxtPosMiddle };
+	
+	IKnobMultiControlText(IPlugBase* pPlug, int x, int y, int paramIdx, IBitmap* pBitmap, IText* pText, bool showParamLabel = true, IKnobMultiControlText::EKnobMultiControlTextPosition labelPosition = kTxtPosBelow)
+	:	IKnobMultiControl(pPlug, x, y, paramIdx, pBitmap)
+	{
+		mText = *pText;
+		//mTextRECT = IRECT(mRECT.L, mRECT.B-20, mRECT.R, mRECT.B);
+		mImgRECT = IRECT(x, y, pBitmap);
+		mDisablePrompt = false;
+		mShowParamLabel = showParamLabel;
+		
+		int captionHeight = pText->mSize + 4;
+		int captionTop;
+		switch (labelPosition) {
+			case kTxtPosBelow:
+				mTextRECT = IRECT(mImgRECT.L, mImgRECT.B, mImgRECT.L+mImgRECT.W(), mImgRECT.T+mImgRECT.H()+captionHeight);
+				break;
+			case kTxtPosAbove:
+				mTextRECT = IRECT(mImgRECT.L, mImgRECT.T-captionHeight, mImgRECT.L+mImgRECT.W(), mImgRECT.T);
+				break;
+			case kTxtPosMiddle:
+				captionTop = mImgRECT.T + (mImgRECT.H()/2) - (captionHeight/2)+2;
+				mTextRECT = IRECT(mImgRECT.L, captionTop, mImgRECT.L+mImgRECT.W(), captionTop+captionHeight);
+				break;
+		}
+	}
+	
+	~IKnobMultiControlText() {}
+	
+	bool Draw(IGraphics* pGraphics);
+	void OnMouseDown(int x, int y, IMouseMod* pMod);
+	void OnMouseDblClick(int x, int y, IMouseMod* pMod);
+
+private:
+	IRECT mTextRECT, mImgRECT;
+	IBitmap mBitmap;
+	WDL_String mStr;
+	bool mShowParamLabel;
+	
 };
 
 #endif


### PR DESCRIPTION
I've added a modified IKnobMultiControlText to the IControl.cpp and IControl.h files. The modified version allows to specify a position for the text (above, in the middle, or below the knob) and autosizes the input box to the size of the text
