### PR TITLE
Compile with 10.10 SDK and C++11

### DIFF
--- a/IPlugExamples/IPlugChunks/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugChunks/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugControls/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugControls/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugConvoEngine/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugConvoEngine/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugDistortion/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugDistortion/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugEEL/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugEEL/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugEffect/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugEffect/app_wrapper/app_dialog.cpp
@@ -568,7 +568,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugGUIResize/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugGUIResize/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugHostDetect/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugHostDetect/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugMonoSynth/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugMonoSynth/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugMouseTest/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugMouseTest/app_wrapper/app_dialog.cpp
@@ -539,7 +539,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugMultiChannel/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugMultiChannel/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugMultiTargets/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugMultiTargets/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugOpenGL/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugOpenGL/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugPlush/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugPlush/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugPolySynth/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugPolySynth/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugResampler/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugResampler/app_wrapper/app_dialog.cpp
@@ -539,7 +539,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugSideChain/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugSideChain/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/IPlugExamples/IPlugText/app_wrapper/app_dialog.cpp
+++ b/IPlugExamples/IPlugText/app_wrapper/app_dialog.cpp
@@ -548,7 +548,7 @@ WDL_DLGRET MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
           if(!gPluginInstance->HostRequestingAboutBox())
           {
             char version[50];
-            sprintf(version, BUNDLE_MFR"\nBuilt on "__DATE__);
+            sprintf(version, BUNDLE_MFR"\nBuilt on " __DATE__);
             MessageBox(hwndDlg,version, BUNDLE_NAME, MB_OK);
           }
           return 0;

--- a/WDL/swell/swell-dlg.mm
+++ b/WDL/swell/swell-dlg.mm
@@ -2371,7 +2371,7 @@ void SWELL_CarbonWndHost_SetWantAllKeys(void* carbonhost, bool want)
 
 - (id)initCarbonChild:(NSView *)parent rect:(Rect*)r composit:(bool)wantComp
 {
-  if (!(self = [super initChild:nil Parent:parent dlgProc:nil Param:nil])) return self;
+  if (!(self = [super initChild:nil Parent:parent dlgProc:nil Param:NULL])) return self;
 
   m_wantallkeys=false;
   


### PR DESCRIPTION
With these two small changes, I've successfully built the IPlugEffect example's APP/VST2/VST3/AU target in 32 and 64 bits for C++11 and OSX 10.10 SDK. I also tried APP/VST2/VST3 on Windows (VS 2013) and it's compiling fine. I couldn't test:

- 10.5 SDK
- RTAS and AAX targets (I don't have the SDKs)

Could you please merge these? Thank you! :)