### PR TITLE
Support for Retina displays

### DIFF
--- a/WDL/IPlug/IGraphics.h
+++ b/WDL/IPlug/IGraphics.h
@@ -51,6 +51,10 @@ public:
   bool Draw(IRECT* pR);           // The system announces what needs to be redrawn.  Ordering and drawing logic.
   virtual bool DrawScreen(IRECT* pR) = 0;  // Tells the OS class to put the final bitmap on the screen.
 
+#ifdef IPLUG_RETINA_SUPPORT
+  bool IsRetina() { return mRetina; }
+#endif
+	
   // Methods for the drawing implementation class.
   bool DrawBitmap(IBitmap* pBitmap, IRECT* pDest, int srcX, int srcY, const IChannelBlend* pBlend = 0);
   bool DrawRotatedBitmap(IBitmap* pBitmap, int destCtrX, int destCtrY, double angle, int yOffsetZeroDeg = 0, const IChannelBlend* pBlend = 0);
@@ -146,6 +150,7 @@ public:
   IBitmap LoadIBitmap(int ID, const char* name, int nStates = 1, bool framesAreHoriztonal = false);
   IBitmap ScaleBitmap(IBitmap* pSrcBitmap, int destW, int destH);
   IBitmap CropBitmap(IBitmap* pSrcBitmap, IRECT* pR);
+
   void AttachBackground(int ID, const char* name);
   void AttachPanelBackground(const IColor *pColor);
   void AttachKeyCatcher(IControl* pControl);
@@ -232,8 +237,14 @@ public:
   void RetainBitmap(IBitmap* pBitmap);
   void ReleaseBitmap(IBitmap* pBitmap);
   LICE_pixel* GetBits();
+#ifdef IPLUG_RETINA_SUPPORT
+  LICE_pixel* GetBits_2x();
+#endif
   // For controls that need to interface directly with LICE.
   inline LICE_SysBitmap* GetDrawBitmap() const { return mDrawBitmap; }
+#ifdef IPLUG_RETINA_SUPPORT
+  inline LICE_SysBitmap* GetDrawBitmap_2x() const { return mDrawBitmap_2x; }
+#endif
 
   WDL_Mutex mMutex;
 
@@ -260,6 +271,11 @@ protected:
   virtual LICE_IBitmap* OSLoadBitmap(int ID, const char* name) = 0;
   
   LICE_SysBitmap* mDrawBitmap;
+#ifdef IPLUG_RETINA_SUPPORT
+  bool mRetina;
+  LICE_SysBitmap* mDrawBitmap_2x;
+  virtual void CheckIfRetina() { mRetina = false; }
+#endif
   LICE_IFont* CacheFont(IText* pTxt);
   
 #ifdef AAX_API

--- a/WDL/IPlug/IGraphicsMac.h
+++ b/WDL/IPlug/IGraphicsMac.h
@@ -6,7 +6,7 @@
 #endif
 
 // carbon support uses quickdraw methods that have been removed in SDKs > 10.6
-#if __MAC_OS_X_VERSION_MAX_ALLOWED > 1060
+#if !defined(IPLUG_NO_CARBON_SUPPORT) && __MAC_OS_X_VERSION_MAX_ALLOWED > 1060
   #warning Carbon GUIs work best with the 10.6 sdk
 #endif
 
@@ -117,7 +117,10 @@ public:
 
 protected:
   virtual LICE_IBitmap* OSLoadBitmap(int ID, const char* name);
-  
+#ifdef IPLUG_RETINA_SUPPORT
+  void CheckIfRetina();
+#endif
+	
 private:
 #ifndef IPLUG_NO_CARBON_SUPPORT
   IGraphicsCarbon* mGraphicsCarbon;

--- a/WDL/IPlug/IPlugStructs.h
+++ b/WDL/IPlug/IPlugStructs.h
@@ -13,8 +13,12 @@ enum EFileAction { kFileOpen, kFileSave };
 struct IBitmap
 {
   void* mData;
+#ifdef IPLUG_RETINA_SUPPORT
+  void* mData_2x;
+#endif
   int W, H, N;    // N = number of states (for multibitmaps).
   bool mFramesAreHorizontal;
+#ifndef IPLUG_RETINA_SUPPORT
   IBitmap(void* pData = 0, int w = 0, int h = 0, int n = 1, bool framesAreHorizontal = false)
     : mData(pData)
     , W(w)
@@ -22,7 +26,17 @@ struct IBitmap
     , N(n)
     , mFramesAreHorizontal(framesAreHorizontal)
   {}
-
+#else
+  IBitmap(void* pData = 0, void* pData_2x = 0, int w = 0, int h = 0, int n = 1, bool framesAreHorizontal = false)
+    : mData(pData)
+    , mData_2x(pData_2x)
+    , W(w)
+    , H(h)
+    , N(n)
+    , mFramesAreHorizontal(framesAreHorizontal)
+	{}
+#endif
+	
   inline int frameHeight() const { return H / N; }
 };
 


### PR DESCRIPTION
# Support for Retina displays on Mac.

Compile with `IPLUG_RETINA_SUPPORT`. For a standard WDL-OL project, you may only need to provide Retina versions of bitmap resources.
## Bitmaps

When enabled, every bitmap resource **must** have a retina version, named with Apple's convention `@2x` before extension (see [Apple documentation](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html#//apple_ref/doc/uid/TP40012302-CH7-SW28)). An assert at run-time checks if all bitmaps have retina versions and are correctly named.

Retina versions of bitmaps should not be declared in `resources.h`.
## LICE

When using LICE directly, use `IsRetina()` in your drawing function, draw twice the size, then blit on `GetDrawBitmap()` or `GetDrawBitmap_2x()` accordingly.
## Text

Text automatically draws twice the size on retina.
## Primitive drawing functions

All drawing functions in `IGraphics` now support retina too.
## Warnings

Add `IPLUG_RETINA_SUPPORT` to _Prepocessor Macros_ in _Build Settings_ section of your Xcode project. Using a C++ `#define` seems to produce issues at run-time.

Undefined behavior if `IPLUG_RETINA_SUPPORT` is defined on Windows projects.
