### PR TITLE
fixed IRECT sub-rectangle bug

### DIFF
--- a/WDL/IPlug/IPlugStructs.h
+++ b/WDL/IPlug/IPlugStructs.h
@@ -220,7 +220,7 @@ struct IRECT
 
   inline IRECT SubRectVertical(int numSlices, int sliceIdx)
   {
-    int heightOfSubRect = (H() / numSlices);
+    float heightOfSubRect = (float(H()) / numSlices);
     int t = heightOfSubRect * sliceIdx;
 
     return IRECT(L, T + t, R, T + t + heightOfSubRect);
@@ -228,7 +228,7 @@ struct IRECT
 
   inline IRECT SubRectHorizontal(int numSlices, int sliceIdx)
   {
-    int widthOfSubRect = (W() / numSlices);
+    float widthOfSubRect = (float(W()) / numSlices);
     int l = widthOfSubRect * sliceIdx;
 
     return IRECT(L + l, T, L + l + widthOfSubRect, B);


### PR DESCRIPTION
Upcasted variable with calculation of height and width of sub rectangle to float so as to avoid truncation.
The rounding error becomes particularly relevant if the slice index is very high
