### PR TITLE
Make duplicate script compatible with Python 3

### DIFF
--- a/IPlugExamples/duplicate.py
+++ b/IPlugExamples/duplicate.py
@@ -93,7 +93,7 @@ def dirwalk(dir, searchproject, replaceproject, searchman, replaceman):
         for x in dirwalk(fullpath, searchproject, replaceproject, searchman, replaceman):
           yield x
       elif (f in SUBFOLDERS_TO_SEARCH):
-        print 'recursing in ' + f + ' directory: '
+        print('recursing in ' + f + ' directory: ')
         for x in dirwalk(fullpath, searchproject, replaceproject, searchman, replaceman):
           yield x
 


### PR DESCRIPTION
One of the `print` commands in duplicate.py was missing parentheses, which is not supported in Python 3.