### PR TITLE
Removed old lines from component manager

### DIFF
--- a/WDL/IPlug/IPlugAU.cpp
+++ b/WDL/IPlug/IPlugAU.cpp
@@ -1422,8 +1422,6 @@ OSStatus IPlugAU::SetState(CFPropertyListRef pPropList)
   AudioComponentDescription cd;
   AudioComponent comp = AudioComponentInstanceGetComponent(mCI);
   OSStatus r = AudioComponentGetDescription(comp, &cd);
-  AudioComponentDescription cd;
-  OSStatus r = GetComponentInfo((Component) mCI, &cd, 0, 0, 0);
 #endif
   
   if (r != noErr)


### PR DESCRIPTION
There are two old lines from the component manager stuff when you select your target osx >= than 10.7 that fail building, i've  removed them and everything worked fine 