### PR TITLE
Fix documentation styling for IControl.h

### DIFF
--- a/IPlug/IGraphics/IControl.h
+++ b/IPlug/IGraphics/IControl.h
@@ -67,7 +67,13 @@ public:
   void PromptUserInput();
   void PromptUserInput(IRECT& rect);
   
+  /*!
+   * @param tooltip Text to be displayed
+   */
   inline void SetTooltip(const char* tooltip) { mTooltip.Set(tooltip); }
+  /*!
+   * \return Currently set tooltip text
+   */
   inline const char* GetTooltip() const { return mTooltip.Get(); }
 
   int ParamIdx() { return mParamIdx; }
@@ -86,7 +92,14 @@ public:
   virtual void TextFromTextEntry( const char* txt ) {}
   virtual void OnContextSelection(int itemSelected) {}
 
+  /*!
+   * Shows or hides the IControl
+   * @param hide Set to true to hide the control
+   */
   virtual void Hide(bool hide);
+  /*!
+   * @return True if the control is hidden. Defaults to false
+   */
   bool IsHidden() const { return mHide; }
 
   virtual void GrayOut(bool gray);

--- a/IPlug/IGraphics/IControl.h
+++ b/IPlug/IGraphics/IControl.h
@@ -22,10 +22,10 @@ public:
   /**
    Constructor
 
-   @param plug - the IPlugBaseGraphics that the control belongs to
-   @param rect - the rectangular area that the control occupies
-   @param paramIdx - if this is > -1 (kNoParameter) this control will be associated with a plugin parameter
-   @param blendType - blend operation
+   @param plug The IPlugBaseGraphics that the control belongs to
+   @param rect The rectangular area that the control occupies
+   @param paramIdx If this is > -1 (kNoParameter) this control will be associated with a plugin parameter
+   @param blendType Blend operation
    */
   IControl(IPlugBaseGraphics& plug, IRECT rect, int paramIdx = kNoParameter, IBlend blendType = IBlend::kBlendNone)
   : mPlug(plug)
@@ -94,11 +94,11 @@ public:
 
   /*!
    * Shows or hides the IControl
-   * @param hide Set to true to hide the control
+   * @param hide Set to \c true to hide the control
    */
   virtual void Hide(bool hide);
   /*!
-   * @return True if the control is hidden. Defaults to false
+   * @return \c true if the control is hidden. Defaults to \c false
    */
   bool IsHidden() const { return mHide; }
 


### PR DESCRIPTION
Monospace font for true/false
Removed redundant "-" in parameters list from the constructor documentation