### PR TITLE
adds symmetric param shape

### DIFF
--- a/IPlug/IPlugParameter.cpp
+++ b/IPlug/IPlugParameter.cpp
@@ -79,7 +79,7 @@ double IParam::DBToAmp() const
 
 void IParam::SetNormalized(double normalizedValue)
 {
-  mValue = FromNormalizedParam(normalizedValue, mMin, mMax, mShape);
+  mValue = FromNormalizedParam(normalizedValue, mMin, mMax, mShape, mShapeSymmetry);
   
   if (mType != kTypeDouble)
   {
@@ -97,17 +97,17 @@ double IParam::GetNormalized() const
 double IParam::GetNormalized(double nonNormalizedValue) const
 {
   nonNormalizedValue = BOUNDED(nonNormalizedValue, mMin, mMax);
-  return ToNormalizedParam(nonNormalizedValue, mMin, mMax, mShape);
+  return ToNormalizedParam(nonNormalizedValue, mMin, mMax, mShape, mShapeSymmetry);
 }
 
 double IParam::GetNonNormalized(double normalizedValue) const
 {
-  return FromNormalizedParam(normalizedValue, mMin, mMax, mShape);
+  return FromNormalizedParam(normalizedValue, mMin, mMax, mShape, mShapeSymmetry);
 }
 
 void IParam::GetDisplayForHost(double value, bool normalized, char* rDisplay, bool withDisplayText)
 {
-  if (normalized) value = FromNormalizedParam(value, mMin, mMax, mShape);
+  if (normalized) value = FromNormalizedParam(value, mMin, mMax, mShape, mShapeSymmetry);
 
   if (withDisplayText)
   {

--- a/IPlug/IPlugParameter.h
+++ b/IPlug/IPlugParameter.h
@@ -30,6 +30,7 @@ public:
   void SetCanAutomate(bool canAutomate) { mCanAutomate = canAutomate; }
   // The higher the shape, the more resolution around host value zero.
   void SetShape(double shape);
+  void SetShapeSymmetry(bool symmetric) { mShapeSymmetry = symmetric; }
   void SetIsMeta(bool meta) { mIsMeta = meta; }
   void SetToDefault() { mValue = mDefault; }
 
@@ -67,16 +68,16 @@ public:
   const char* GetNameForHost() const;
   const char* GetLabelForHost() const;
   const char* GetParamGroupForHost() const;
-  
+
   int GetNDisplayTexts() const;
   const char* GetDisplayText(int value) const;
   const char* GetDisplayTextAtIdx(int idx, int* value = 0) const;
   bool MapDisplayText(const char* pStr, int* pValue) const;  // Reverse map back to value.
-  
+
   double GetShape() const { return mShape; }
   double GetStep() const { return mStep; }
   double GetDefault() const { return mDefault; }
-  double GetDefaultNormalized() const { return ToNormalizedParam(mDefault, mMin, mMax, mShape); }
+  double GetDefaultNormalized() const { return ToNormalizedParam(mDefault, mMin, mMax, mShape, mShapeSymmetry); }
   double GetMin() const { return mMin; }
   double GetMax() const { return mMax; }
   void GetBounds(double& lo, double& hi) const;
@@ -84,7 +85,7 @@ public:
   int GetPrecision() const {return mDisplayPrecision;}
   bool GetCanAutomate() const { return mCanAutomate; }
   bool GetIsMeta() const { return mIsMeta; }
-  
+
   void GetJSON(WDL_String& json, int idx) const;
 
 private:
@@ -100,15 +101,16 @@ private:
   bool mSignDisplay = false;
   bool mCanAutomate = true;
   bool mIsMeta = false;
+  bool mShapeSymmetry = false; // todo check what's with AAX_ITaperDelegate and IPlugVST3::process()
   char mName[MAX_PARAM_NAME_LEN];
   char mLabel[MAX_PARAM_LABEL_LEN];
   char mParamGroup[MAX_PARAM_LABEL_LEN];
-  
+
   struct DisplayText
   {
     int mValue;
     char mText[MAX_PARAM_DISPLAY_LEN];
   };
-  
+
   WDL_TypedBuf<DisplayText> mDisplayTexts;
 } WDL_FIXALIGN;

--- a/IPlug/IPlugUtilities.h
+++ b/IPlug/IPlugUtilities.h
@@ -112,14 +112,56 @@ inline void GetVersionStr(int version, WDL_String& str)
   str.SetFormatted(MAX_VERSION_STR_LEN, "v%d.%d.%d", ver, rmaj, rmin);
 }
 
-inline double ToNormalizedParam(double nonNormalizedValue, double min, double max, double shape)
+inline double ToNormalizedSymmetric(double nonNormalizedValue, double min, double max, double shape)
 {
-  return std::pow((nonNormalizedValue - min) / (max - min), 1.0 / shape);
+  const auto mid = 0.5 * (max + min);
+  const auto halfRange = max - mid;
+  auto d = nonNormalizedValue - mid;
+
+  if (d < 0.0)
+    return 0.5 - 0.5 * pow(2.0 * -d, 1.0 / shape);
+
+  else
+    return 0.5 + 0.5 * pow(2.0 * d, 1.0 / shape);
 }
 
-inline double FromNormalizedParam(double normalizedValue, double min, double max, double shape)
+inline double FromNormalizedSymmetric(double normalizedValue, double min, double max, double shape)
 {
-  return min + std::pow((double) normalizedValue, shape) * (max - min);
+  const auto mid = 0.5 * (max + min);
+  const auto halfRange = max - mid;
+  auto d = normalizedValue - 0.5;
+
+  if (d < 0.0)
+    return mid - halfRange * pow(2.0 * -d, shape);
+
+  else
+    return mid + halfRange * pow(2.0 * d, shape);
+}
+
+inline double ToNormalizedParam(double nonNormalizedValue, double min, double max, double shape, bool symmetric = false)
+{
+  switch (symmetric)
+  {
+  default:
+  case false:
+    return pow((nonNormalizedValue - min) / (max - min), 1.0 / shape);
+
+  case true:
+    return ToNormalizedSymmetric(nonNormalizedValue, min, max, shape);
+  }
+}
+
+inline double FromNormalizedParam(double normalizedValue, double min, double max, double shape, bool symmetric = false)
+{
+  switch (symmetric)
+  {
+  default:
+  case false:
+    return min + pow((double) normalizedValue, shape) * (max - min);
+
+  case true:
+    return FromNormalizedSymmetric(normalizedValue, min, max, shape);
+  }
 }
 
 template <class SRC, class DEST>


### PR DESCRIPTION
example: param has a range -100.0, 100.0 and needs more precision near 0.0.
however this needs to match AAX_ITaperDelegate and IPlugVST3::process() implementations. Haven't touch those because I don't know some specifics.