### PR TITLE
Fix notice message to point to the right file and references

### DIFF
--- a/IPlugExamples/duplicate.py
+++ b/IPlugExamples/duplicate.py
@@ -175,7 +175,7 @@ def main():
 
     copy('gitignore_template', output + "/.gitignore")
 
-    print("\ndone - don't forget to change PLUG_UID and MFR_UID in config.h")
+    print("\ndone - don't forget to change PLUG_UNIQUE_ID and PLUG_MFR_ID in resource.h")
     
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
Hi,

I just duplicated an IPlug example for the first time and was wondering why I couldn't find config.h and the respective references. Turns out, the message printed is misleading :) I guess it's just a merge glitch as I watched a youtube video of an older rev of the project where the message were right. 